### PR TITLE
Fix compile error on BSD

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,8 @@
 .PHONY: all clean
 
 CC	?= cc
-CFLAGS	+= -std=c89 -Wall -pedantic
+CFLAGS	+= -static -std=c89 -Wall -pedantic
+LDFLAGS	+= -lm
 
 all:	woe
 


### PR DESCRIPTION
Closes #1.

Previously:
```
$ make -n
echo "CC\twoe.c"
cc -c -std=c89 -Wall -pedantic woe.c
echo "LINK\twoe"
cc -o woe woe.o 
```
Now:
```
$ make -n
echo "CC\twoe.c"
cc -c -static -std=c89 -Wall -pedantic woe.c
echo "LINK\twoe"
cc -o woe woe.o -lm
```
Tested on OS X.